### PR TITLE
Add customer mandates endpoint

### DIFF
--- a/lib/Entities/Customer.php
+++ b/lib/Entities/Customer.php
@@ -2,6 +2,7 @@
 
 namespace PayPro\Entities;
 
+use PayPro\Exception\ApiErrorException;
 use PayPro\Operations\Delete;
 use PayPro\Operations\Request;
 use PayPro\Operations\Update;
@@ -15,5 +16,21 @@ class Customer extends Resource
     public function resourcePath()
     {
         return 'customers';
+    }
+
+    /**
+     * Returns all mandates for this customer.
+     *
+     * @param array $params
+     *
+     * @return Collection a list with the mandates
+     *
+     * @throws ApiErrorException if the request fails
+     */
+    public function mandates($params = [])
+    {
+        $url = $this->resourceUrl() . '/mandates';
+
+        return $this->apiRequest('get', $url, $params);
     }
 }

--- a/tests/PayPro/Entities/CustomerTest.php
+++ b/tests/PayPro/Entities/CustomerTest.php
@@ -48,4 +48,25 @@ final class CustomerTest extends TestCase
         $responseCustomer = $customer->update(['address' => 'Gangpad 11']);
         self::assertInstanceOf(Customer::class, $responseCustomer);
     }
+
+    public function testMandates()
+    {
+        $response = $this->getFixture('customers/mandates.json');
+        $data = json_decode($this->getFixture('customers/get.json'), true);
+
+        $this->stubRequest(
+            'get',
+            '/customers/CU10TV703T84E0/mandates',
+            null,
+            null,
+            null,
+            $response
+        );
+
+        $customer = new Customer($data, $this->apiClient);
+
+        $mandates = $customer->mandates();
+        self::assertInstanceOf(Collection::class, $mandates);
+        self::assertInstanceOf(Mandate::class, $mandates->first());
+    }
 }

--- a/tests/fixtures/customers/mandates.json
+++ b/tests/fixtures/customers/mandates.json
@@ -1,0 +1,21 @@
+{
+  "type": "list",
+  "count": 1,
+  "data": [
+    {
+      "id": "MD6ULYXJ4HP9RJ",
+      "type": "mandate",
+      "state": "approved",
+      "customer": "CUWSWVVPTL94VX",
+      "pay_method": "direct-debit",
+      "created_at": "2024-03-11T16:59:06Z",
+      "_links": {
+        "self": "http://api.paypro.test:3000/mandates/MD6ULYXJ4HP9RJ",
+        "customer": "http://api.paypro.test:3000/customers/CUWSWVVPTL94VX"
+      }
+    }
+  ],
+  "_links": {
+    "self": "https://api.paypro.nl/customers/CUWSWVVPTL94VX/mandates"
+  }
+}


### PR DESCRIPTION
Adds the `GET /customers/:id/mandates` endpoint.